### PR TITLE
Write summary to results/training_summary.json

### DIFF
--- a/train_hybrid_models.py
+++ b/train_hybrid_models.py
@@ -1399,6 +1399,26 @@ class HybridModelTrainer:
         
         with open(results_file, 'w') as f:
             json.dump(summary, f, indent=2, default=str)
+
+        # Update consolidated training summary
+        summary_path = "results/training_summary.json"
+        existing_summary = {}
+        if os.path.exists(summary_path) and os.path.getsize(summary_path) > 0:
+            try:
+                with open(summary_path, "r") as f:
+                    existing_summary = json.load(f)
+            except Exception:
+                existing_summary = {}
+
+        if isinstance(existing_summary, dict):
+            existing_summary[summary["timestamp"]] = summary
+        elif isinstance(existing_summary, list):
+            existing_summary.append(summary)
+        else:
+            existing_summary = {summary["timestamp"]: summary}
+
+        with open(summary_path, "w") as f:
+            json.dump(existing_summary, f, indent=2, default=str)
         
         # Print final summary
         print(f"\n{'='*80}")


### PR DESCRIPTION
## Summary
- save walk-forward aggregated results to a consolidated `results/training_summary.json`
- keep history of previous runs rather than overwriting

## Testing
- `python3 -m py_compile train_hybrid_models.py`

------
https://chatgpt.com/codex/tasks/task_e_6873a56106bc83328ac594e1d574ae4e