### PR TITLE
Add warm start and feature column enhancements

### DIFF
--- a/scripts/backtest_models.py
+++ b/scripts/backtest_models.py
@@ -145,7 +145,10 @@ class ModelBacktester:
                     try:
                         # First try: standard loading
                         from train_hybrid_models import directional_loss
-lstm_model = load_model(lstm_path, custom_objects={"directional_loss": directional_loss})
+                        lstm_model = load_model(
+                            lstm_path,
+                            custom_objects={"directional_loss": directional_loss}
+                        )
                     except Exception as e1:
                         try:
                             # Second try: with compile=False for compatibility


### PR DESCRIPTION
## Summary
- add warm-start support for walk-forward training
- save feature columns per window and load them in the model loader
- expose CLI options for data/models directories and warm start
- fix indentation bug in backtest_models script

## Testing
- `pytest -q`
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68739fcf92508332b1a0f601300eda8c