### PR TITLE
Implement Boruta selection and CNN-LSTM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ seaborn>=0.12.0
 
 # ===== TECHNICAL ANALYSIS =====
 pandas-ta>=0.3.14b
+Boruta>=0.4.3
 
 # ===== UTILITIES =====
 attrs>=17.3.0


### PR DESCRIPTION
## Summary
- use BorutaPy to select the most relevant XGBoost features
- add quantile loss implementation
- build CNN-LSTM architecture and apply quantile loss
- create purged walk-forward windows with an embargo period
- add Boruta dependency

## Testing
- `pytest -q`
- `python -m py_compile train_hybrid_models.py`

------
https://chatgpt.com/codex/tasks/task_e_6873bb1736f48332ac28a515bcb67c3a