### PR TITLE
Improve model loading and trading risk controls

### DIFF
--- a/train_hybrid_models.py
+++ b/train_hybrid_models.py
@@ -119,7 +119,7 @@ def quantile_loss(q):
     return loss
 
 # Standalone directional loss function for proper serialization
-@tf.keras.utils.register_keras_serializable()
+@tf.keras.utils.register_keras_serializable(package="Custom", name="directional_loss")
 def directional_loss(y_true, y_pred):
     """
     Custom loss function that penalizes wrong directional predictions more


### PR DESCRIPTION
## Summary
- fix serialization registration for `directional_loss`
- robust loading of LSTM models with a compile-free fallback
- simplify window selection to always use the most recent model
- add `calculate_position_size` for dynamic sizing in `SignalGenerator`
- use new sizing logic when generating buy signals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bfd9aac0833287acf5603e681f62