### PR TITLE
Handle LR schedule optimizer callbacks

### DIFF
--- a/train_hybrid_models.py
+++ b/train_hybrid_models.py
@@ -791,11 +791,16 @@ class HybridModelTrainer:
                 patience=10,
                 restore_best_weights=True,
                 min_delta=1e-5,
-            ),
-            ReduceLROnPlateau(
-                monitor="val_loss", factor=0.5, patience=5, min_lr=1e-6, verbose=0
-            ),
+            )
         ]
+
+        # Only add ReduceLROnPlateau when the optimizer's learning rate is settable
+        if not isinstance(optimizer.learning_rate, tf.keras.optimizers.schedules.LearningRateSchedule):
+            callbacks.append(
+                ReduceLROnPlateau(
+                    monitor="val_loss", factor=0.5, patience=5, min_lr=1e-6, verbose=0
+                )
+            )
 
         # Train model with conservative memory management to prevent crashes
         # Start with moderate batch size and implement robust fallback


### PR DESCRIPTION
## Summary
- avoid ReduceLROnPlateau error when optimizer uses a learning rate schedule
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c66eeba48332862df4abe0060028