### PR TITLE
Implement sliding walk-forward windows

### DIFF
--- a/README_TRAINING.md
+++ b/README_TRAINING.md
@@ -145,7 +145,7 @@ For each time window:
 📊 Loaded 95,847 candles for BTCEUR
 📅 Date range: 2020-01-01 to 2025-01-11
 ✅ Created 32 technical features
-🔄 Generated 54 walk-forward windows
+🔄 Generated 54 sliding walk-forward windows
 
 🔄 Window 1/54: 2020-01-01 to 2020-08-01
 🧠 LSTM Training: 17,280 sequences

--- a/train_hybrid_models.py
+++ b/train_hybrid_models.py
@@ -496,7 +496,13 @@ class HybridModelTrainer:
     def generate_walk_forward_windows(
         self, df: pd.DataFrame
     ) -> List[Tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp, pd.Timestamp]]:
-        """Generate purged walk-forward windows with embargo."""
+        """Generate sliding walk-forward windows with purge and embargo gaps.
+
+        Each window uses ``self.train_months`` of data for training and
+        ``self.test_months`` for testing. Windows advance by ``self.step_months``
+        to create a sliding sequence while the purge/embargo gaps between the
+        training and testing segments are preserved.
+        """
 
         windows = []
         start = df.index.min()
@@ -516,10 +522,10 @@ class HybridModelTrainer:
                 break
 
             windows.append((train_start, train_end, test_start, test_end))
-            current_start = test_end + embargo
+            current_start = current_start + pd.DateOffset(months=self.step_months)
 
         print(
-            f"📅 Generated {len(windows)} walk-forward windows with purging and embargo"
+            f"📅 Generated {len(windows)} sliding walk-forward windows with purging and embargo"
         )
         return windows
 


### PR DESCRIPTION
## Summary
- make walk-forward windows slide by `step_months`
- clarify sliding-window behavior in the docs

## Testing
- `python` snippet to generate windows with default dataset

------
https://chatgpt.com/codex/tasks/task_e_6873cdff672083329d69534210cd10dc