### PR TITLE
Fix warm-start model loading

### DIFF
--- a/ENHANCED_MODEL_GUIDE.md
+++ b/ENHANCED_MODEL_GUIDE.md
@@ -159,7 +159,7 @@ Inputs → LSTM(128) → BatchNorm → LSTM(64) → BatchNorm → LSTM(32) → A
 
 ### Model Files
 - `models/lstm/{symbol}_lstm_window_{i}.h5`: LSTM models
-- `models/xgboost/{symbol}_xgboost_window_{i}.pkl`: XGBoost models
+- `models/xgboost/{symbol}_xgboost_window_{i}.json`: XGBoost models
 - `models/scalers/{symbol}_scaler_window_{i}.pkl`: Feature scalers
 
 ### Results Files

--- a/README_TRAINING.md
+++ b/README_TRAINING.md
@@ -35,7 +35,7 @@ trade_bot_2.0/
 │   └── xrpeur_15m.db
 ├── 🤖 models/                        # Trained models (created by training)
 │   ├── lstm/                         # LSTM models (.h5 files)
-│   ├── xgboost/                      # XGBoost models (.pkl files)
+│   ├── xgboost/                      # XGBoost models (.json files)
 │   └── scalers/                      # Data scalers (.pkl files)
 ├── 📊 results/                       # Training results and analysis
 │   ├── training_summary.json
@@ -194,7 +194,7 @@ models/
 │   ├── btceur_history.pkl          # Training history
 │   └── ... (other symbols)
 ├── xgboost/
-│   ├── btceur_xgboost.pkl          # Trained XGBoost model
+│   ├── btceur_xgboost.json         # Trained XGBoost model
 │   └── ... (other symbols)
 └── scalers/
     ├── btceur_scaler.pkl           # Data scaler for LSTM
@@ -373,15 +373,15 @@ After training completes:
 ### Loading Trained Models
 
 ```python
-import pickle
+import xgboost as xgb
 import tensorflow as tf
 
 # Load LSTM model
 lstm_model = tf.keras.models.load_model('models/lstm/btceur_lstm.h5')
 
 # Load XGBoost model
-with open('models/xgboost/btceur_xgboost.pkl', 'rb') as f:
-    xgb_model = pickle.load(f)
+xgb_model = xgb.XGBClassifier()
+xgb_model.load_model('models/xgboost/btceur_xgboost.json')
 
 # Load scaler
 with open('models/scalers/btceur_scaler.pkl', 'rb') as f:

--- a/paper_trader/models/model_loader.py
+++ b/paper_trader/models/model_loader.py
@@ -89,12 +89,12 @@ class WindowBasedModelLoader:
             # Scan XGBoost models
             xgb_dir = self.model_path / 'xgboost'
             if xgb_dir.exists():
-                for xgb_file in xgb_dir.glob(f"{symbol_lower}_window_*.pkl"):
+                for xgb_file in xgb_dir.glob(f"{symbol_lower}_window_*.json"):
                     try:
                         window_num = int(xgb_file.stem.split('_window_')[1])
                         windows_found.add(window_num)
-                        with open(xgb_file, 'rb') as f:
-                            model = pickle.load(f)
+                        model = xgb.XGBClassifier()
+                        model.load_model(xgb_file)
                         self.xgb_models[symbol][window_num] = model
                         self.logger.debug(f"Loaded XGBoost model for {symbol} window {window_num}")
                     except (ValueError, Exception) as e:

--- a/scripts/backtest_models.py
+++ b/scripts/backtest_models.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import numpy as np
 import sqlite3
-import pickle
 import joblib
+import xgboost as xgb
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, roc_auc_score, confusion_matrix
 import matplotlib.pyplot as plt
@@ -169,15 +169,12 @@ class ModelBacktester:
                 print(f"    LSTM model file not found: {lstm_path}")
             
             # Load XGBoost model
-            xgb_path = f'models/xgboost/{symbol.lower()}_window_{window_num}.pkl'
+            xgb_path = f'models/xgboost/{symbol.lower()}_window_{window_num}.json'
             xgb_model = None
             if os.path.exists(xgb_path):
                 try:
-                    with open(xgb_path, 'rb') as f:
-                        import warnings
-                        with warnings.catch_warnings():
-                            warnings.simplefilter("ignore")
-                            xgb_model = pickle.load(f)
+                    xgb_model = xgb.XGBClassifier()
+                    xgb_model.load_model(xgb_path)
                     print(f"    XGBoost model loaded successfully for window {window_num}")
                 except Exception as e:
                     print(f"    XGBoost model loading failed for window {window_num}: {e}")

--- a/train_hybrid_models.py
+++ b/train_hybrid_models.py
@@ -1675,7 +1675,7 @@ class HybridModelTrainer:
             # Train XGBoost with timing
             print(f"🌳 Starting XGBoost training for window {i+1}...")
             xgb_start = time.time()
-            prev_xgb_path = f"{self.models_dir}/xgboost/{symbol.lower()}_window_{i}.pkl"
+            prev_xgb_path = f"{self.models_dir}/xgboost/{symbol.lower()}_window_{i}.json"
             warm_start_path = (
                 prev_xgb_path
                 if (self.warm_start and i > 0 and os.path.exists(prev_xgb_path))
@@ -1771,10 +1771,9 @@ class HybridModelTrainer:
             lstm_model.save(
                 f"{self.models_dir}/lstm/{symbol.lower()}_window_{i+1}.keras"
             )
-            with open(
-                f"{self.models_dir}/xgboost/{symbol.lower()}_window_{i+1}.pkl", "wb"
-            ) as f:
-                pickle.dump(xgb_model, f)
+            xgb_model.save_model(
+                f"{self.models_dir}/xgboost/{symbol.lower()}_window_{i+1}.json"
+            )
             with open(
                 f"{self.models_dir}/scalers/{symbol.lower()}_window_{i+1}_scaler.pkl",
                 "wb",
@@ -1785,10 +1784,9 @@ class HybridModelTrainer:
             if i == len(windows) - 1:  # Last window
                 # Save final models
                 lstm_model.save(f"{self.models_dir}/lstm/{symbol.lower()}_lstm.h5")
-                with open(
-                    f"{self.models_dir}/xgboost/{symbol.lower()}_xgboost.pkl", "wb"
-                ) as f:
-                    pickle.dump(xgb_model, f)
+                xgb_model.save_model(
+                    f"{self.models_dir}/xgboost/{symbol.lower()}_xgboost.json"
+                )
                 with open(
                     f"{self.models_dir}/scalers/{symbol.lower()}_scaler.pkl", "wb"
                 ) as f:


### PR DESCRIPTION
## Summary
- save XGBoost models using `save_model` JSON format
- update warm start and backtesting logic to load these JSON files
- document new `.json` filenames in training guides

## Testing
- `pytest -q` *(fails: pandas_ta ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68740ee87e10833294fd439bbbb24056