### PR TITLE
Improve paper trader model handling and data validation

### DIFF
--- a/paper_trader/models/feature_engineer.py
+++ b/paper_trader/models/feature_engineer.py
@@ -16,6 +16,14 @@ LSTM_FEATURES: List[str] = [
     'momentum_10', 'price_zscore_20'
 ]
 
+# Full feature list used during model training
+TRAINING_FEATURES: List[str] = [
+    'returns', 'log_returns', 'price_change_1h', 'price_change_4h',
+    'volatility_20', 'atr_ratio', 'rsi', 'macd', 'bb_position',
+    'volume_ratio', 'price_vs_ema9', 'price_vs_ema21', 'buying_pressure',
+    'selling_pressure', 'spread_ratio', 'momentum_10', 'price_zscore_20'
+]
+
 class FeatureEngineer:
     """Creates technical indicators and features for ML models."""
     
@@ -25,6 +33,14 @@ class FeatureEngineer:
     def get_lstm_feature_columns(self) -> List[str]:
         """Return LSTM feature column order used during training."""
         return LSTM_FEATURES
+
+    def validate_features(self, df: pd.DataFrame) -> bool:
+        """Validate that all required features are present."""
+        missing_features = set(TRAINING_FEATURES) - set(df.columns)
+        if missing_features:
+            self.logger.warning(f"Missing features: {missing_features}")
+            return False
+        return True
         
     def engineer_features(self, data: pd.DataFrame) -> Optional[pd.DataFrame]:
         """Create the same technical indicators used during model training."""

--- a/paper_trader/models/performance_tracker.py
+++ b/paper_trader/models/performance_tracker.py
@@ -1,0 +1,9 @@
+class ModelPerformanceTracker:
+    def __init__(self):
+        self.window_performance = {}
+
+    def track_prediction(self, symbol, window, predicted, actual, market_conditions):
+        pass
+
+    def get_best_window(self, symbol, current_market_conditions):
+        pass

--- a/scripts/convert_models.py
+++ b/scripts/convert_models.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+from paper_trader.models.model_loader import directional_loss
+
+
+def convert_models(symbol: str):
+    """Load legacy model and resave with proper serialization."""
+    model = tf.keras.models.load_model(f"models/lstm/{symbol}_window_X.keras", compile=False)
+    model.compile(optimizer='adam', loss=directional_loss, metrics=['mae'])
+    model.save(f"models/lstm/{symbol}_window_X_converted.keras")
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) != 2:
+        print("Usage: python convert_models.py SYMBOL")
+    else:
+        convert_models(sys.argv[1])


### PR DESCRIPTION
## Summary
- improve custom loss handling and window selection in model loader
- add training features list and feature validation method
- track prediction uncertainty in ensemble predictor
- add candle validation and feature caching in data collector
- provide a model conversion script and performance tracker skeleton

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ff14d314833280784a830946b5b7