### PR TITLE
Remove LSTM dropout to use CuDNN kernels

### DIFF
--- a/train_hybrid_models.py
+++ b/train_hybrid_models.py
@@ -718,8 +718,8 @@ class HybridModelTrainer:
         lstm1 = LSTM(
             self.lstm_units[0],
             return_sequences=True,
-            dropout=self.dropout_rate,
-            recurrent_dropout=self.dropout_rate,
+            dropout=0.0,
+            recurrent_dropout=0.0,
         )(x)
         lstm1 = BatchNormalization()(lstm1)
 
@@ -727,8 +727,8 @@ class HybridModelTrainer:
         lstm2 = LSTM(
             self.lstm_units[1],
             return_sequences=True,
-            dropout=self.dropout_rate,
-            recurrent_dropout=self.dropout_rate,
+            dropout=0.0,
+            recurrent_dropout=0.0,
         )(lstm1)
         lstm2 = BatchNormalization()(lstm2)
 
@@ -736,8 +736,8 @@ class HybridModelTrainer:
         lstm3 = LSTM(
             self.lstm_units[2],
             return_sequences=True,
-            dropout=self.dropout_rate,
-            recurrent_dropout=self.dropout_rate,
+            dropout=0.0,
+            recurrent_dropout=0.0,
         )(lstm2)
         lstm3 = BatchNormalization()(lstm3)
 


### PR DESCRIPTION
## Summary
- disable dropout on LSTM layers so TensorFlow will use CuDNN kernels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875020750108332a25b802e618ba6a6