### PR TITLE
Fix sequence length and features

### DIFF
--- a/paper_trader/models/feature_engineer.py
+++ b/paper_trader/models/feature_engineer.py
@@ -16,6 +16,9 @@ LSTM_FEATURES: List[str] = [
     'momentum_10', 'price_zscore_20'
 ]
 
+# Sequence length used during model training
+LSTM_SEQUENCE_LENGTH: int = 96
+
 # Full feature list used during model training
 TRAINING_FEATURES: List[str] = [
     'returns', 'log_returns', 'price_change_1h', 'price_change_4h',


### PR DESCRIPTION
## Summary
- add `LSTM_SEQUENCE_LENGTH` constant for consistent sequence sizing
- load only `_selected` feature column lists for XGBoost models
- fix LSTM prediction to use the fixed training length
- validate feature column availability in XGBoost prediction

## Testing
- `python -m py_compile paper_trader/models/feature_engineer.py paper_trader/models/model_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68773a3b54f883328185ba8f53368029