### PR TITLE
Improve prediction fallback

### DIFF
--- a/main_paper_trader.py
+++ b/main_paper_trader.py
@@ -321,6 +321,7 @@ class PaperTrader:
             # Set ensemble weights from settings
             self.predictor.lstm_weight = self.settings.lstm_weight
             self.predictor.xgb_weight = self.settings.xgb_weight
+            self.predictor.caboose_weight = self.settings.caboose_weight
             
             # Initialize signal generator
             self.signal_generator = SignalGenerator(

--- a/paper_trader/config/settings.py
+++ b/paper_trader/config/settings.py
@@ -48,6 +48,7 @@ class TradingSettings:
     # Ensemble Model Weights
     lstm_weight: float = float(os.getenv('LSTM_WEIGHT', '0.6'))
     xgb_weight: float = float(os.getenv('XGB_WEIGHT', '0.4'))
+    caboose_weight: float = float(os.getenv('CABOOSE_WEIGHT', '0.3'))
     
     # Risk Management
     max_daily_loss_pct: float = float(os.getenv('MAX_DAILY_LOSS_PCT', '0.05'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ tensorflow[and-cuda]>=2.15.0  # Alternative: use this for automatic CUDA setup
 # nvidia-cudnn-cu12>=8.9.0
 # nvidia-cuda-runtime-cu12>=12.0
 xgboost>=2.0.0
+catboost>=1.2.0
 
 # ===== VISUALIZATION =====
 matplotlib>=3.7.0

--- a/requirements_paper_trader.txt
+++ b/requirements_paper_trader.txt
@@ -9,6 +9,7 @@ scikit-learn>=1.1.0
 # Machine Learning
 tensorflow==2.15.0
 xgboost>=1.6.0
+catboost>=1.2.0
 joblib>=1.2.0
 
 # Technical Analysis (TA-Lib removed - install separately if needed)


### PR DESCRIPTION
## Summary
- load optional Caboose (CatBoost) models and predictions
- allow XGBoost predictions even when some features are missing
- expose caboose weight in settings and wire through to the predictor
- update dependency lists with catboost

## Testing
- `python -m py_compile paper_trader/models/model_loader.py main_paper_trader.py paper_trader/config/settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68773c51bc248332925aa6c06e08873f