### PR TITLE
Change default threshold to 0.5%

### DIFF
--- a/train_hybrid_models.py
+++ b/train_hybrid_models.py
@@ -197,9 +197,10 @@ class HybridModelTrainer:
         # Enhanced Model parameters
         self.lstm_sequence_length = 96  # 24 hours of 15-min candles (increased from 60)
         self.prediction_horizon = 1  # Next 15-min candle
-        self.price_change_threshold = (
-            0.001  # 0.1% for binary classification (more sensitive)
-        )
+        # Binary classification target: predict if price will rise at least 0.5%
+        # by the next candle. Adjust the threshold here to retrain models with
+        # a different price change objective.
+        self.price_change_threshold = 0.005
 
         # Advanced LSTM parameters (optimized for better GPU utilization)
         self.lstm_units = [256, 128, 64]  # Increased units for better GPU utilization


### PR DESCRIPTION
## Summary
- increase `price_change_threshold` to 0.005 in `train_hybrid_models.py`
- add explanatory comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c7d17b3083329455fd2e75eaa534