### PR TITLE
Fix scaler warning and refresh prices

### DIFF
--- a/main_paper_trader.py
+++ b/main_paper_trader.py
@@ -413,6 +413,9 @@ class PaperTrader:
                 self.logger.warning(f"Could not get sufficient data for {symbol}, skipping")
                 return False
 
+            # Refresh latest price so our buffer has the most recent close
+            await self.data_collector.refresh_latest_price(symbol)
+
             # Fetch latest data from buffer for feature engineering
             data = self.data_collector.get_buffer_data(symbol, min_length=500)
             if data is None or len(data) < 500:

--- a/paper_trader/models/feature_engineer.py
+++ b/paper_trader/models/feature_engineer.py
@@ -335,7 +335,9 @@ class FeatureEngineer:
             if scaler is not None:
                 feature_cols = self.get_feature_names(data)
                 data_scaled = data.copy()
-                data_scaled[feature_cols] = scaler.transform(data[feature_cols])
+                data_scaled[feature_cols] = scaler.transform(
+                    data[feature_cols].to_numpy()
+                )
                 return data_scaled, scaler
             else:
                 return data, None

--- a/paper_trader/models/model_loader.py
+++ b/paper_trader/models/model_loader.py
@@ -408,7 +408,9 @@ class WindowBasedEnsemblePredictor:
             feature_data = features.copy()
             feature_cols = [col for col in LSTM_FEATURES if col in feature_data.columns]
             if scaler is not None and feature_cols:
-                feature_data[feature_cols] = scaler.transform(feature_data[feature_cols])
+                feature_data[feature_cols] = scaler.transform(
+                    feature_data[feature_cols].to_numpy()
+                )
             
             # Create sequence for LSTM using fixed training length
             sequence_length = min(LSTM_SEQUENCE_LENGTH, len(feature_data))


### PR DESCRIPTION
## Summary
- refresh latest price before generating predictions
- avoid `StandardScaler` feature name warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d2e988508332a3eaaab8a207de8e