### PR TITLE
Fix scaler warning

### DIFF
--- a/scripts/backtest_models.py
+++ b/scripts/backtest_models.py
@@ -284,7 +284,9 @@ class ModelBacktester:
         lstm_features = ['close', 'volume']
         
         # Scale the data (use transform only, scaler is already fitted)
-        scaled_data = scaler.transform(data[lstm_features].fillna(method='ffill'))
+        scaled_data = scaler.transform(
+            data[lstm_features].fillna(method='ffill').to_numpy()
+        )
         
         sequences = []
         for i in range(self.config.sequence_length, len(scaled_data)):


### PR DESCRIPTION
## Summary
- avoid StandardScaler feature name warning in backtest script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d63c04c8833286753a33f2224866