### PR TITLE
Ensure predictions use latest price

### DIFF
--- a/main_paper_trader.py
+++ b/main_paper_trader.py
@@ -435,8 +435,10 @@ class PaperTrader:
                 self.logger.warning(f"Insufficient features for {symbol}")
                 return False
             
-            # Get current price
-            current_price = await self.data_collector.get_current_price(symbol)
+            # Get current price using buffer first for consistency
+            current_price = self.data_collector.get_latest_price(symbol)
+            if current_price is None:
+                current_price = await self.data_collector.get_current_price(symbol)
             if current_price is None:
                 self.logger.warning(f"Could not get current price for {symbol}")
                 return False


### PR DESCRIPTION
## Summary
- use latest buffered close price before calling API for current price
- avoid overwriting buffer with stale prices
- use latest buffer price in `process_symbol`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877da5558248332926e4771305ea446