### PR TITLE
Allow configurable candle interval

### DIFF
--- a/main_paper_trader.py
+++ b/main_paper_trader.py
@@ -308,7 +308,8 @@ class PaperTrader:
             # Initialize data collector
             self.data_collector = BitvavoDataCollector(
                 api_key=self.settings.bitvavo_api_key,
-                api_secret=self.settings.bitvavo_api_secret
+                api_secret=self.settings.bitvavo_api_secret,
+                interval=self.settings.candle_interval
             )
             
             # Initialize feature engineer
@@ -639,7 +640,10 @@ class PaperTrader:
                 self.data_collector.start_websocket_feed(self.settings.symbols)
             )
             self.api_update_task = asyncio.create_task(
-                self.data_collector.update_data_periodically(self.settings.symbols)
+                self.data_collector.update_data_periodically(
+                    self.settings.symbols,
+                    interval_minutes=1
+                )
             )
 
             # Initialize last prediction timestamps

--- a/paper_trader/config/settings.py
+++ b/paper_trader/config/settings.py
@@ -30,6 +30,9 @@ class TradingSettings:
     stop_loss_pct: float = float(os.getenv('STOP_LOSS_PCT', '0.01'))
     trailing_stop_pct: float = float(os.getenv('TRAILING_STOP_PCT', '0.005'))
     max_hold_hours: int = int(os.getenv('MAX_HOLD_HOURS', '2'))
+
+    # Data interval for candles
+    candle_interval: str = os.getenv('CANDLE_INTERVAL', '15m')
     
     # Symbols
     symbols: List[str] = None


### PR DESCRIPTION
## Summary
- add `candle_interval` option to `TradingSettings`
- parameterize `BitvavoDataCollector` with interval and use it for REST and WS
- initialize collector with `candle_interval` and fetch 1 minute updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas_ta')*

------
https://chatgpt.com/codex/tasks/task_e_6877e963a8e08332bce56a1dce90f8ba