### PR TITLE
Set candle interval default to 1m

### DIFF
--- a/README_paper_trader.md
+++ b/README_paper_trader.md
@@ -4,7 +4,7 @@ A sophisticated paper trading system that uses machine learning models to simula
 
 ## Features
 
-- **Real-time Data Collection**: 15-minute OHLCV data via Bitvavo WebSocket and REST API
+- **Real-time Data Collection**: 1-minute OHLCV data (default) via Bitvavo WebSocket and REST API
 - **Machine Learning Integration**: Supports LSTM and XGBoost ensemble predictions
 - **Advanced Risk Management**: 1% take profit/stop loss, trailing stops, time-based exits
 - **Portfolio Management**: Track up to 10 concurrent positions with 10% position sizing
@@ -130,7 +130,7 @@ The system will:
 1. Initialize all components
 2. Load your ML models
 3. Start real-time data collection
-4. Begin the 15-minute trading cycle
+4. Begin the 1-minute trading cycle (default)
 5. Send Telegram notifications for trades and hourly updates
 
 ## Key Features Explained
@@ -150,7 +150,7 @@ The system will:
 - Emergency stop conditions
 
 ### Data Collection
-- Real-time 15-minute OHLCV data
+- Real-time 1-minute OHLCV data (default)
 - WebSocket feed for live updates
 - Historical data initialization
 - Automatic data buffer management

--- a/main_paper_trader.py
+++ b/main_paper_trader.py
@@ -150,7 +150,9 @@ class PaperTrader:
                 
                 # Test historical data fetch
                 try:
-                    test_data = await self.data_collector.get_historical_data(symbol, '15m', 10)
+                    test_data = await self.data_collector.get_historical_data(
+                        symbol, self.settings.candle_interval, 10
+                    )
                     if test_data is not None and len(test_data) > 0:
                         self.logger.info(f"    ✅ Can fetch historical data: {len(test_data)} candles")
                     else:
@@ -680,7 +682,7 @@ class PaperTrader:
                         await self.send_hourly_update()
                         self.last_hourly_update = now
                     
-                    # Wait before next cycle (15 minutes to align with data intervals)
+                    # Wait before next cycle (1 minute to align with data interval)
                     if self.is_running:
                         self.logger.debug("Waiting for next cycle...")
                         await asyncio.sleep(60)  # 1 minute for debugging

--- a/paper_trader/config/settings.py
+++ b/paper_trader/config/settings.py
@@ -32,7 +32,7 @@ class TradingSettings:
     max_hold_hours: int = int(os.getenv('MAX_HOLD_HOURS', '2'))
 
     # Data interval for candles
-    candle_interval: str = os.getenv('CANDLE_INTERVAL', '15m')
+    candle_interval: str = os.getenv('CANDLE_INTERVAL', '1m')
     
     # Symbols
     symbols: List[str] = None


### PR DESCRIPTION
## Summary
- default candle interval to 1m
- reference configurable interval in diagnostics
- update cycle wait comment
- document new default timeframe

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6877efd6e1c8833280ac9d066cc5fa5c