### PR TITLE
Fix stale price usage in predictions

### DIFF
--- a/main_paper_trader.py
+++ b/main_paper_trader.py
@@ -454,8 +454,10 @@ class PaperTrader:
             price_data = features_df['close'].tail(20)  # Use last 20 periods
             market_volatility = price_data.std() / price_data.mean() if len(price_data) > 1 else 0.5
             
-            # Generate enhanced prediction with market volatility
-            prediction_result = await self.predictor.predict(symbol, features_df, market_volatility)
+            # Generate enhanced prediction with market volatility and current price
+            prediction_result = await self.predictor.predict(
+                symbol, features_df, market_volatility, current_price
+            )
             if prediction_result is None:
                 return False
 


### PR DESCRIPTION
## Summary
- inject optional `current_price` into `WindowBasedEnsemblePredictor.predict`
- propagate the price to LSTM, XGBoost and CatBoost prediction helpers
- compute `lstm_delta` and signal strength with the fresh price
- pass the latest price from `process_symbol` when predicting

## Testing
- `python3 -m py_compile main_paper_trader.py paper_trader/models/model_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6877f1e6dcb4833290994830bca9b0d0