### PR TITLE
Fix missing get_latest_price method

### DIFF
--- a/paper_trader/data/bitvavo_collector.py
+++ b/paper_trader/data/bitvavo_collector.py
@@ -460,7 +460,17 @@ class BitvavoDataCollector:
                     )
         except Exception as e:
             self.logger.warning(f"Failed to refresh price for {symbol}: {e}")
-    
+
+    def get_latest_price(self, symbol: str) -> Optional[float]:
+        """Return the most recent close price stored for a symbol."""
+        try:
+            if symbol in self.data_buffers and not self.data_buffers[symbol].empty:
+                return float(self.data_buffers[symbol]["close"].iloc[-1])
+            return None
+        except Exception as e:
+            self.logger.error(f"Error getting latest price for {symbol}: {e}")
+            return None
+
     async def start_websocket_feed(self, symbols: List[str]):
         """Start WebSocket feed for real-time data updates."""
         while True:


### PR DESCRIPTION
## Summary
- implement `get_latest_price` on `BitvavoDataCollector`
- keep unit tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785509b9d4833284aec434e05031b0