### PR TITLE
Add prediction-based exit and trading cycle improvements

### DIFF
--- a/paper_trader/config/settings.py
+++ b/paper_trader/config/settings.py
@@ -60,6 +60,13 @@ class TradingSettings:
     max_drawdown_pct: float = float(os.getenv('MAX_DRAWDOWN_PCT', '0.10'))
     # Minimum expected gain (prediction threshold)
     min_expected_gain_pct: float = float(os.getenv('MIN_EXPECTED_GAIN_PCT', '0.0003'))
+
+    # Prediction-based exit parameters
+    enable_prediction_exits: bool = os.getenv('ENABLE_PREDICTION_EXITS', 'True') == 'True'
+    prediction_exit_min_confidence: float = float(os.getenv('PREDICTION_EXIT_MIN_CONFIDENCE', '0.7'))
+    prediction_exit_min_strength: str = os.getenv('PREDICTION_EXIT_MIN_STRENGTH', 'STRONG')
+    prediction_lookback_periods: int = int(os.getenv('PREDICTION_LOOKBACK_PERIODS', '5'))
+    dynamic_stop_loss_adjustment: bool = os.getenv('DYNAMIC_STOP_LOSS_ADJUSTMENT', 'True') == 'True'
     
     def __post_init__(self):
         """Initialize symbols list from environment variable."""

--- a/paper_trader/notifications/telegram_notifier.py
+++ b/paper_trader/notifications/telegram_notifier.py
@@ -217,6 +217,20 @@ class TelegramNotifier:
         except Exception as e:
             self.logger.error(f"Error creating daily summary message: {e}")
             return False
+
+    async def send_prediction_exit_alert(self, symbol: str, confidence: float,
+                                          signal_strength: str, pnl: float):
+        """Send alert for prediction-based exit."""
+        message = (
+            f"🔮 <b>Prediction Exit Triggered</b>\n\n"
+            f"📊 Symbol: <code>{symbol}</code>\n"
+            f"🎯 Model Confidence: <code>{confidence:.1%}</code>\n"
+            f"⚡ Signal Strength: <code>{signal_strength}</code>\n"
+            f"💰 P&L: <code>${pnl:+.2f}</code>\n\n"
+            f"🧠 AI detected potential reversal - position closed proactively"
+        )
+
+        return await self.send_message(message)
     
     async def send_market_alert(self, symbol: str, alert_type: str, message_text: str) -> bool:
         """Send market-related alerts."""

--- a/paper_trader/strategy/prediction_trend.py
+++ b/paper_trader/strategy/prediction_trend.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+class PredictionTrendAnalyzer:
+    def __init__(self, lookback_periods: int = 5):
+        self.lookback_periods = lookback_periods
+        self.prediction_history = {}
+
+    def add_prediction(self, symbol: str, prediction: dict):
+        if symbol not in self.prediction_history:
+            self.prediction_history[symbol] = []
+        self.prediction_history[symbol].append({
+            'timestamp': datetime.now(),
+            'prediction': prediction
+        })
+        if len(self.prediction_history[symbol]) > self.lookback_periods:
+            self.prediction_history[symbol] = self.prediction_history[symbol][-self.lookback_periods:]
+
+    def is_trend_deteriorating(self, symbol: str) -> bool:
+        if symbol not in self.prediction_history:
+            return False
+        recent_predictions = self.prediction_history[symbol][-3:]
+        if len(recent_predictions) >= 2:
+            latest = recent_predictions[-1]['prediction']
+            previous = recent_predictions[-2]['prediction']
+            confidence_declining = latest.get('confidence', 0) < previous.get('confidence', 0)
+            direction_negative = latest.get('direction') == 'DOWN'
+            return confidence_declining and direction_negative
+        return False


### PR DESCRIPTION
## Summary
- extend ExitManager with prediction-based exit checks and dynamic stop loss
- add PredictionTrendAnalyzer utility
- update Telegram alerts for prediction-based exits
- expose new prediction exit parameters in settings
- refactor PaperTrader with `run_trading_cycle` using prediction monitoring

## Testing
- `python -m py_compile main_paper_trader.py paper_trader/strategy/exit_manager.py paper_trader/notifications/telegram_notifier.py paper_trader/config/settings.py paper_trader/strategy/prediction_trend.py`

------
https://chatgpt.com/codex/tasks/task_e_6878962589f48332888f647ba39d0cd8