### PR TITLE
Fix Binance data collector microsecond bug

### DIFF
--- a/README_DATA_COLLECTOR.md
+++ b/README_DATA_COLLECTOR.md
@@ -136,6 +136,9 @@ ORDER BY date;
 1. **Network Errors**: The program will retry automatically
 2. **Rate Limiting**: Built-in delays prevent rate limit issues
 3. **Incomplete Data**: Check logs for specific error messages
+4. **Out of Bounds Timestamp Errors**: Binance switched to microsecond
+   timestamps for bulk files in 2025. Update to the latest collector version
+   if you see `Out of bounds nanosecond` messages.
 
 ### Logs
 

--- a/binance_data_collector.py
+++ b/binance_data_collector.py
@@ -130,7 +130,12 @@ class BinanceDataCollector:
                         'close_time', 'quote_volume', 'trades', 'taker_buy_base',
                         'taker_buy_quote', 'ignore'
                     ])
-            
+
+            # Normalize timestamps (Binance switched to microseconds in 2025)
+            df['timestamp'] = pd.to_numeric(df['timestamp'], errors='coerce')
+            if df['timestamp'].abs().max() > 1e14:
+                df['timestamp'] = (df['timestamp'] // 1000).astype('int64')
+
             # Add human-readable datetime
             df['datetime'] = pd.to_datetime(df['timestamp'], unit='ms')
             
@@ -238,7 +243,11 @@ class BinanceDataCollector:
         
         df['timestamp'] = pd.to_numeric(df['timestamp'], errors='coerce')
         df['trades'] = pd.to_numeric(df['trades'], errors='coerce')
-        
+
+        # Normalize timestamps (microseconds handling)
+        if df['timestamp'].abs().max() > 1e14:
+            df['timestamp'] = (df['timestamp'] // 1000).astype('int64')
+
         # Add human-readable datetime
         df['datetime'] = pd.to_datetime(df['timestamp'], unit='ms')
         


### PR DESCRIPTION
## Summary
- fix timestamp units for 2025 bulk files
- document how to resolve `Out of bounds nanosecond` errors

## Testing
- `python -m py_compile binance_data_collector.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6879a100f30083328e370104c6c69343