### PR TITLE
Fix unnecessary f-strings

### DIFF
--- a/optimization_config.py
+++ b/optimization_config.py
@@ -222,7 +222,7 @@ def run_custom_optimization(
         save_top_n=10
     )
     
-    print(f"🎯 Running custom optimization:")
+    print("🎯 Running custom optimization:")
     print(f"   Method: {method}")
     print(f"   Objective: {objective}")
     print(f"   Symbols: {symbols}")
@@ -312,7 +312,7 @@ if __name__ == "__main__":
         print(f"🚀 Running preset optimization: {args.preset}")
         results = run_preset_optimization(args.preset, args.symbols)
     else:
-        print(f"🎯 Running custom optimization")
+        print("🎯 Running custom optimization")
         results = run_custom_optimization(
             method=args.method,
             objective=args.objective,


### PR DESCRIPTION
## Summary
- remove unused `f` prefixes in `optimization_config.py`

## Testing
- `pyflakes optimization_config.py`
- `python -m py_compile optimization_config.py`
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_687a1ce95a888332aff4350426daecda