### PR TITLE
Fix sequence length mismatch

### DIFF
--- a/scripts/backtest_models.py
+++ b/scripts/backtest_models.py
@@ -60,7 +60,10 @@ class BacktestConfig:
         self.slide_months = 1
         
         # Data parameters
-        self.sequence_length = 60
+        # Sequence length must match the value used during model training.
+        # Models in this repository were trained with 96 timesteps, so use the
+        # same length here to avoid shape mismatches at inference time.
+        self.sequence_length = 96
         self.price_change_threshold = 0.002
 
 class TechnicalIndicators:


### PR DESCRIPTION
## Summary
- make backtest `sequence_length` match the model

## Testing
- `python -m py_compile scripts/backtest_models.py`


------
https://chatgpt.com/codex/tasks/task_e_687a2b1a00e88332b1fecb65597fe249