### PR TITLE
Fix undefined variable error

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -99,11 +99,15 @@ class OptimizedBacktester(ModelBacktester):
         
         return models
     
-    def simulate_trading_window(self, data, lstm_model, xgb_model, scaler, symbol, initial_capital, positions):
+    def simulate_trading_window(self, data, lstm_model, xgb_model, scaler,
+                                symbol, initial_capital, positions, window_num):
         """Override simulate_trading_window to add debug data collection"""
         if not self.debug_mode:
             # Use parent method if debug mode is disabled
-            return super().simulate_trading_window(data, lstm_model, xgb_model, scaler, symbol, initial_capital, positions)
+            return super().simulate_trading_window(
+                data, lstm_model, xgb_model, scaler,
+                symbol, initial_capital, positions, window_num
+            )
         
         # Debug mode: collect detailed information
         import csv
@@ -145,7 +149,9 @@ class OptimizedBacktester(ModelBacktester):
                 lstm_delta = lstm_pred
                 
                 # XGBoost prediction
-                xgb_features = self.get_xgb_features(data.iloc[:i+1], lstm_delta)
+                xgb_features = self.get_xgb_features(
+                    data.iloc[:i+1], lstm_delta, window_num
+                )
                 xgb_prob = xgb_model.predict_proba(xgb_features)[0][1]
                 
                 # Generate signal
@@ -408,7 +414,8 @@ class OptimizedBacktester(ModelBacktester):
             
             # Simulate trading for this window
             window_trades, window_capital = self.simulate_trading_window(
-                test_data, lstm_model, xgb_model, scaler, symbol, capital, positions
+                test_data, lstm_model, xgb_model, scaler,
+                symbol, capital, positions, window_num
             )
             
             trades.extend(window_trades)

--- a/scripts/backtest_models.py
+++ b/scripts/backtest_models.py
@@ -582,7 +582,8 @@ class ModelBacktester:
             
             # Simulate trading for this window
             window_trades, window_capital = self.simulate_trading_window(
-                test_data, lstm_model, xgb_model, scaler, symbol, capital, positions
+                test_data, lstm_model, xgb_model, scaler,
+                symbol, capital, positions, window_num
             )
             
             trades.extend(window_trades)
@@ -608,8 +609,9 @@ class ModelBacktester:
             'final_capital': capital
         }
     
-    def simulate_trading_window(self, data: pd.DataFrame, lstm_model, xgb_model, scaler, 
-                              symbol: str, initial_capital: float, positions: List[Trade]) -> Tuple[List[Trade], float]:
+    def simulate_trading_window(self, data: pd.DataFrame, lstm_model, xgb_model, scaler,
+                              symbol: str, initial_capital: float, positions: List[Trade],
+                              window_num: int) -> Tuple[List[Trade], float]:
         """Simulate trading for a single window"""
         capital = initial_capital
         window_trades = []


### PR DESCRIPTION
## Summary
- pass window_num through simulate_trading_window
- use window_num when generating XGBoost features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a371d98e08332b9f6ff2b44e0c478