### PR TITLE
feat(paperspace): add env-driven training runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ model_transfer_*.zip
 .env
 .env.local
 .env.backup_with_real_creds
+envs/*.env
 env/
 venv/
 ENV/

--- a/Train.ipynb
+++ b/Train.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Paperspace Training Runner\n",
+    "Use this notebook to trigger the automated training workflow via the reusable shell script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENV_FILE = \"/notebooks/bot/envs/paperspace.env\"  # Update with your actual env file path\n",
+    "print(f\"Using env file: {ENV_FILE}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd bot\n",
+    "!./scripts/run_paperspace_training.sh \"{ENV_FILE}\"\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/envs/paperspace.env.example
+++ b/envs/paperspace.env.example
@@ -1,0 +1,20 @@
+# Example environment file for Paperspace training
+# Copy to envs/paperspace.env (ignored by git) and fill in real values.
+
+# AWS credentials (rotate and keep secret)
+AWS_ACCESS_KEY_ID=YOUR_AWS_KEY
+AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET
+AWS_DEFAULT_REGION=us-east-1
+AWS_MODELS_BUCKET=paperspace-models-youraccount
+
+# App configuration
+APP_ENV=production
+LOG_LEVEL=INFO
+
+# Telegram notifications
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_CHAT_ID=your-telegram-chat-id
+
+# Optional: override repository URL or python binary
+# BOT_REPO_URL=https://github.com/your-org/bot.git
+# PYTHON_BIN=python3

--- a/paperspace_mlops/README.md
+++ b/paperspace_mlops/README.md
@@ -24,6 +24,19 @@ Complete automated MLOps pipeline for training trading bot models on Paperspace 
    - Uses existing databases in `data/` folder (no network fetching)
    - Automatically manages time limits and training parameters
 
+### One-command workflow
+
+If you prefer to mirror the old notebook flow, use the bundled script which
+loads an environment file, pulls the latest code, installs dependencies, and
+launches setup + training:
+
+```bash
+./scripts/run_paperspace_training.sh envs/paperspace.env
+```
+
+Fill `envs/paperspace.env` with your secrets (copy from
+`envs/paperspace.env.example`) and keep it out of source control.
+
 ### On Production Server
 
 1. **Start the webhook server** (to receive models automatically):

--- a/scripts/run_paperspace_training.sh
+++ b/scripts/run_paperspace_training.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Run full Paperspace training workflow with environment file configuration.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<USAGE
+Usage: $0 <env-file> [--skip-s3] [--skip-setup]
+
+Arguments:
+  <env-file>   Path to the environment file to source before running.
+
+Options:
+  --skip-s3    Skip S3 storage provisioning step.
+  --skip-setup Skip environment bootstrap step (paperspace_setup.py).
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+ENV_FILE="$1"
+shift
+
+SKIP_S3=0
+SKIP_SETUP=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-s3)
+      SKIP_S3=1
+      shift
+      ;;
+    --skip-setup)
+      SKIP_SETUP=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Environment file not found: $ENV_FILE" >&2
+  exit 1
+fi
+
+echo "Loading environment from $ENV_FILE"
+set -o allexport
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +o allexport
+
+echo "Using repository root: $REPO_ROOT"
+
+GIT_REMOTE_URL="${BOT_REPO_URL:-}"
+if [[ -n "$GIT_REMOTE_URL" ]]; then
+  echo "Pulling latest changes from $GIT_REMOTE_URL"
+  git -C "$REPO_ROOT" pull "$GIT_REMOTE_URL"
+else
+  echo "Pulling latest changes from default remote"
+  git -C "$REPO_ROOT" pull --ff-only || true
+fi
+
+cd "$REPO_ROOT"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if [[ -f "requirements.txt" ]]; then
+  echo "Installing base requirements"
+  "$PYTHON_BIN" -m pip install -r requirements.txt
+fi
+
+if [[ -f "paperspace_mlops/requirements_paperspace.txt" ]]; then
+  echo "Installing Paperspace-specific requirements"
+  "$PYTHON_BIN" -m pip install -r paperspace_mlops/requirements_paperspace.txt
+fi
+
+if [[ $SKIP_SETUP -eq 0 ]]; then
+  echo "Running Paperspace environment setup"
+  "$PYTHON_BIN" paperspace_mlops/paperspace_setup.py
+else
+  echo "Skipping environment setup as requested"
+fi
+
+if [[ $SKIP_S3 -eq 0 ]]; then
+  echo "Configuring S3 storage"
+  if [[ -f "paperspace_mlops/setup_s3_storage.py" ]]; then
+    "$PYTHON_BIN" paperspace_mlops/setup_s3_storage.py
+  elif [[ -f "setup_s3_storage.py" ]]; then
+    "$PYTHON_BIN" setup_s3_storage.py
+  else
+    echo "setup_s3_storage.py not found; skipping S3 provisioning" >&2
+  fi
+else
+  echo "Skipping S3 storage setup as requested"
+fi
+
+echo "Starting training pipeline"
+"$PYTHON_BIN" paperspace_mlops/paperspace_training.py


### PR DESCRIPTION
## Summary
Briefly describe the change and its scope.

## Risk & Service Impact
- Risk level: low / medium / high
- Affects running services? systemd or tmux sessions: yes / no
- Requires config change (`.env`, `training_config.yaml`): yes / no

## Testing Evidence
- Unit/integration tests run: `pytest -q` / `pytest --cov=src`
- System scripts: `python quick_test_system.py` / `python comprehensive_test_system.py` / `python final_test_system.py`
- Logs/screenshots (if applicable):

## Rollback Plan
How to revert safely (e.g., `git revert <sha>`, config toggle, or stop script).

## Checklist
- [ ] No secrets committed; uses `.env`
- [ ] Docs updated (AGENTS.md/README)
- [ ] Lint/format clean (`flake8`, `black`)
- [ ] Verified tmux/service status unaffected or planned
